### PR TITLE
Fourfront utils in snovault and case insensitive sorting

### DIFF
--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -14,6 +14,7 @@ from snovault import (
     TYPES,
 )
 from snovault.schema_utils import combine_schemas
+from snovault.fourfront_utils import add_default_embeds
 from .interfaces import ELASTIC_SEARCH
 import collections
 import json
@@ -103,6 +104,10 @@ def schema_mapping(name, schema, field='*'):
                 'raw': {
                     'type': 'string',
                     'index': 'not_analyzed'
+                },
+                'lower_case_sort': {
+                    'type': 'string',
+                    'analyzer': 'case_insensistive_sort'
                 }
             }
         }
@@ -115,6 +120,10 @@ def schema_mapping(name, schema, field='*'):
                 'raw': {
                     'type': 'string',
                     'index': 'not_analyzed'
+                },
+                'lower_case_sort': {
+                    'type': 'string',
+                    'analyzer': 'case_insensistive_sort'
                 }
             }
         }
@@ -138,6 +147,10 @@ def schema_mapping(name, schema, field='*'):
                                 'raw': {
                                     'type': 'string',
                                     'index': 'not_analyzed'
+                                },
+                                'lower_case_sort': {
+                                    'type': 'string',
+                                    'analyzer': 'case_insensistive_sort'
                                 }
                             }
                         })
@@ -159,6 +172,10 @@ def schema_mapping(name, schema, field='*'):
                 'raw': {
                     'type': 'string',
                     'index': 'not_analyzed'
+                },
+                'lower_case_sort': {
+                    'type': 'string',
+                    'analyzer': 'case_insensistive_sort'
                 }
             }
         }
@@ -171,6 +188,10 @@ def schema_mapping(name, schema, field='*'):
                 'raw': {
                     'type': 'string',
                     'index': 'not_analyzed'
+                },
+                'lower_case_sort': {
+                    'type': 'string',
+                    'analyzer': 'case_insensistive_sort'
                 }
             }
         }
@@ -222,6 +243,12 @@ def index_settings():
                             'standard',
                             'lowercase',
                             'asciifolding'
+                        ]
+                    },
+                    'case_insensistive_sort': {
+                        'tokenizer': 'keyword',
+                        'filter': [
+                            'lowercase',
                         ]
                     },
                     'snovault_path_analyzer': {
@@ -416,11 +443,11 @@ def type_mapping(types, item_type, embed=True):
     type_info = types[item_type]
     schema = type_info.schema
     mapping = schema_mapping(item_type, schema)
+    embeds = add_default_embeds(type_info.embedded, schema)
     if not embed:
         return mapping
     embed_obj = {}  # overall embedded object
-
-    for prop in type_info.embedded:
+    for prop in embeds:
         single_embed = {}
         s = schema
         m = mapping
@@ -528,7 +555,6 @@ def run(app, collections=None, dry_run=False, check_first=True):
 
     if not collections:
         collections = ['meta'] + list(registry[COLLECTIONS].by_item_type.keys())
-
     for collection_name in collections:
         if collection_name == 'meta':
             doc_type = 'meta'

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -446,7 +446,6 @@ def type_mapping(types, item_type, embed=True):
     embeds = add_default_embeds(type_info.embedded, schema)
     if not embed:
         return mapping
-    embed_obj = {}  # overall embedded object
     for prop in embeds:
         single_embed = {}
         s = schema

--- a/src/snovault/fourfront_utils.py
+++ b/src/snovault/fourfront_utils.py
@@ -1,0 +1,32 @@
+# Basic fourfront-specific utilities that seem to have a good home in snovault
+
+def add_default_embeds(embeds, schema={}):
+    """Perform default processing on the embeds list.
+    This adds display_title to any non-fully embedded linkTo field and defaults
+    to using the @id and display_title of non-embedded linkTo's
+    Used in fourfront/../types/base.py AND snovault create mapping
+    """
+    if 'properties' in schema:
+        schema = schema['properties']
+    processed_fields = embeds[:] if len(embeds) > 0 else []
+    already_processed = []
+    # find pre-existing fields
+    for field in embeds:
+        split_field = field.strip().split('.')
+        if len(split_field) > 1:
+            embed_path = '.'.join(split_field[:-1])
+            if embed_path not in processed_fields and embed_path not in already_processed:
+                already_processed.append(embed_path)
+                if embed_path + '.link_id' not in processed_fields:
+                    processed_fields.append(embed_path + '.link_id')
+                if embed_path + '.display_title' not in processed_fields:
+                    processed_fields.append(embed_path + '.display_title')
+    # automatically embed top level linkTo's not already embedded
+    for key, val in schema.items():
+        check_linkTo = 'linkTo' in val or ('items' in val and 'linkTo' in val['items'])
+        if key not in processed_fields and check_linkTo:
+            if key + '.link_id' not in processed_fields:
+                processed_fields.append(key + '.link_id')
+            if key + '.display_title' not in processed_fields:
+                processed_fields.append(key + '.display_title')
+    return processed_fields


### PR DESCRIPTION
Added case_insensitive analyzer for sorting in elasticsearch queries. Also added a new file, fourfront_utils.py, which contains add_default_embeds. This is called in create_mapping now to ensure default embeds are mapped.