### PR TITLE
FF-705

### DIFF
--- a/src/snovault/elasticsearch/__init__.py
+++ b/src/snovault/elasticsearch/__init__.py
@@ -37,8 +37,8 @@ def includeme(config):
         config.include('.esstorage')
 
     config.include('.indexer')
-    # if asbool(settings.get('indexer')) and not PY2:
-    #     config.include('.mpindexer')
+    if asbool(settings.get('indexer')) and not PY2:
+        config.include('.mpindexer')
 
 
 def datastore(request):

--- a/src/snovault/elasticsearch/__init__.py
+++ b/src/snovault/elasticsearch/__init__.py
@@ -37,8 +37,8 @@ def includeme(config):
         config.include('.esstorage')
 
     config.include('.indexer')
-    if asbool(settings.get('indexer')) and not PY2:
-        config.include('.mpindexer')
+    # if asbool(settings.get('indexer')) and not PY2:
+    #     config.include('.mpindexer')
 
 
 def datastore(request):

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -8,6 +8,7 @@ from pyramid.compat import (
 )
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.traversal import find_resource
+from pyramid.interfaces import IRoutesMapper
 import logging
 log = logging.getLogger(__name__)
 
@@ -146,7 +147,8 @@ def identify_invalid_embed(request, path, use_literal=False):
         use_path = '/'.join(proc_path)
     if len(path) == 0 or path[0] != '/':
         return invalid_return_val
-    if use_path in ['', '/', '/session-properties', '/me', '/favicon.ico']:
+    mapper = request.registry.queryUtility(IRoutesMapper)
+    if mapper.get_route(path.strip('/')):
         return 'valid'
     try:
         find_attempt = find_resource(request.root, use_path)

--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -70,8 +70,6 @@ def embed(request, *elements, **kw):
     path = join(*elements)
     path = unquote_bytes_to_wsgi(native_(path))
     # check to see if this embed is a non-object field
-    if path == 'mixed ectoderm/mesoderm/endoderm-derived structure/@@object':
-        import pdb; pdb.set_trace()
     invalid_check = identify_invalid_embed(request, path)
     if invalid_check != 'valid':
         return invalid_check
@@ -126,9 +124,14 @@ def identify_invalid_embed(request, path):
     the object needed for that field will already be handled.
     Return the value of the non-obj field, else 'valid' if obj can be embedded
     """
+    if len(path) == 0 or path[0] != '/':
+        return path
     split_path = path.split('/')
     proc_path = [sub for sub in split_path if sub[:2] != '@@']
     use_path = '/'.join(proc_path)
+    print('----->', use_path)
+    if use_path in ['', '/', '/session-properties', '/me', '/favicon.ico']:
+        return 'valid'
     try:
         find_attempt = find_resource(request.root, use_path)
     except KeyError: # KeyError is due to path not found
@@ -138,7 +141,6 @@ def identify_invalid_embed(request, path):
     except TypeError:
         return split_path[0]
     return 'valid' # this obj can be embedded (a valid resource path)
-
 
 
 def parse_embedded_result(request, result, fields_to_embed):

--- a/src/snovault/resource_views.py
+++ b/src/snovault/resource_views.py
@@ -255,9 +255,12 @@ def item_view_columns(context, request):
 @view_config(context=Item, permission='view_raw', request_method='GET',
              name='raw')
 def item_view_raw(context, request):
+    props = context.properties
     if asbool(request.params.get('upgrade', True)):
-        return context.upgrade_properties()
-    return context.properties
+        props =  context.upgrade_properties()
+    # add uuid to raw view
+    props['uuid'] = str(context.uuid)
+    return props
 
 
 @view_config(context=Item, permission='edit', request_method='GET',

--- a/src/snowflakes/tests/data/inserts/lab.json
+++ b/src/snowflakes/tests/data/inserts/lab.json
@@ -201,7 +201,7 @@
         "awards": [
             "U41HG006992"
         ],
-        "city": "Stanford",
+        "city": "Stanford/USA/",
         "country": "USA",
         "fax": "000-000-0000",
         "institute_label": "Stanford",

--- a/src/snowflakes/tests/test_search.py
+++ b/src/snowflakes/tests/test_search.py
@@ -34,7 +34,10 @@ def test_selective_embedding(workbook, testapp):
     assert isinstance(test_json[0]['award'], dict)
     assert test_json[0]['award']['start_date'] == '2012-09-21'
     # since award.pi was not specifically embedded, pi field should not exist
+    # (removed @id-like field)
     assert 'pi' not in test_json[0]['award']
+    # @id-like field that should still be embedded (not a valid @id)
+    assert test_json[0]['lab']['city'] == '/Stanford/USA/'
 
 
 


### PR DESCRIPTION
In embed.py, made identify_invalid_embed use Pyramid's find_resource and get_route functions to actually confirm object location and static routes, respectively. This is a big improvement on the previous method, which was based around string recognition.

Added a small test in test_search to accompany these changes.